### PR TITLE
Avoid printing sensitive information

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectTwoManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectTwoManager.java
@@ -187,7 +187,7 @@ public class SauceConnectTwoManager implements SauceTunnelManager {
                 workingDirectory = new File(getSauceConnectWorkingDirectory());
             }
             processBuilder.directory(workingDirectory);
-            logMessage(printStream, "Launching Sauce Connect " + Arrays.toString(args));
+            julLogger.log(Level.INFO, "Launching Sauce Connect " + Arrays.toString(args));
 
             final Process process = processBuilder.start();
             try {


### PR DESCRIPTION
Hi,

When using Jenkins with the sauce ondemand plugin, the saucelabs user and API access key are exposed in the console output of the builds.
