### PR TITLE
Adding regex replace for log output

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -219,7 +219,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
 
             args = generateSauceConnectArgs(args, username, apiKey, port, options);
 
-            julLogger.log(Level.INFO, "Launching Sauce Connect " + getCurrentVersion() + " " + Arrays.toString(args));
+            julLogger.log(Level.INFO, "Launching Sauce Connect " + getCurrentVersion() + " " + Arrays.toString(args).replaceAll("\\w+-\\w+-\\w+-\\w+-\\w+", "****"));
             return createProcess(args, unzipDirectory);
         } catch (IOException e) {
             throw new SauceConnectException(e);


### PR DESCRIPTION
Adding regex replace for access keys. This will stop the access-key from being printed to the console.

https://github.com/saucelabs/ci-sauce/issues/28