### PR TITLE
Change source and target compilation levels to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                	<source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
The project uses `com.saucelabs:saucerest` dependency which requires Java 7, so default compilation level should be increased from 6 to 7.