### PR TITLE
Clean up

### DIFF
--- a/src/main/java/com/saucelabs/ci/Browser.java
+++ b/src/main/java/com/saucelabs/ci/Browser.java
@@ -26,7 +26,7 @@ public class Browser implements Comparable<Browser> {
 
     private static final Map<String, String> oses;
     static {
-        Map<String, String> aMap = new HashMap<String, String>();
+        Map<String, String> aMap = new HashMap<>();
         aMap.put("windows 10", "Windows 10");
         aMap.put("windows 2012 r2", "Windows 8.1");
         aMap.put("windows 2012", "Windows 8");

--- a/src/main/java/com/saucelabs/ci/BrowserFactory.java
+++ b/src/main/java/com/saucelabs/ci/BrowserFactory.java
@@ -10,7 +10,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.logging.Level;
@@ -51,15 +50,12 @@ public class BrowserFactory {
         try {
             initializeWebDriverBrowsers();
             initializeAppiumBrowsers();
-        } catch (IOException e) {
-            //TODO exception could mean we're behind firewall
-            logger.log(Level.WARNING, "Error retrieving browsers, attempting to continue", e);
         } catch (JSONException e) {
             logger.log(Level.WARNING, "Error retrieving browsers, attempting to continue", e);
         }
     }
 
-    public List<Browser> getAppiumBrowsers() throws IOException, JSONException {
+    public List<Browser> getAppiumBrowsers() throws JSONException {
         List<Browser> browsers;
         if (shouldRetrieveBrowsers()) {
             browsers = initializeAppiumBrowsers();
@@ -71,7 +67,7 @@ public class BrowserFactory {
         return browsers;
     }
 
-    public List<Browser> getWebDriverBrowsers() throws IOException, JSONException {
+    public List<Browser> getWebDriverBrowsers() throws JSONException {
         List<Browser> browsers;
         if (shouldRetrieveBrowsers()) {
             browsers = initializeWebDriverBrowsers();
@@ -87,7 +83,7 @@ public class BrowserFactory {
         return lastLookup == null || CacheTimeUtil.pastAcceptableDuration(lastLookup, ONE_HOUR_IN_MILLIS);
     }
 
-    private List<Browser> initializeAppiumBrowsers() throws IOException, JSONException {
+    private List<Browser> initializeAppiumBrowsers() throws JSONException {
         List<Browser> browsers = getAppiumBrowsersFromSauceLabs();
         appiumLookup = new HashMap<String, Browser>();
         for (Browser browser : browsers) {
@@ -97,7 +93,7 @@ public class BrowserFactory {
         return browsers;
     }
 
-    private List<Browser> initializeWebDriverBrowsers() throws IOException, JSONException {
+    private List<Browser> initializeWebDriverBrowsers() throws JSONException {
         List<Browser> browsers = getWebDriverBrowsersFromSauceLabs();
         webDriverLookup = new HashMap<String, Browser>();
         for (Browser browser : browsers) {
@@ -107,7 +103,7 @@ public class BrowserFactory {
         return browsers;
     }
 
-    private List<Browser> getWebDriverBrowsersFromSauceLabs() throws IOException, JSONException {
+    private List<Browser> getWebDriverBrowsersFromSauceLabs() throws JSONException {
         String response = sauceREST.getSupportedPlatforms("webdriver");
         if (response.equals("")) {
             response = "[]";
@@ -115,7 +111,7 @@ public class BrowserFactory {
         return getBrowserListFromJson(response);
     }
 
-    private List<Browser> getAppiumBrowsersFromSauceLabs() throws IOException, JSONException {
+    private List<Browser> getAppiumBrowsersFromSauceLabs() throws JSONException {
         String response = sauceREST.getSupportedPlatforms("appium");
         if (response.equals("")) {
             response = "[]";

--- a/src/main/java/com/saucelabs/ci/BrowserFactory.java
+++ b/src/main/java/com/saucelabs/ci/BrowserFactory.java
@@ -29,9 +29,9 @@ public class BrowserFactory {
 
     private SauceREST sauceREST;
 
-    private Map<String, Browser> seleniumLookup = new HashMap<String, Browser>();
-    private Map<String, Browser> appiumLookup = new HashMap<String, Browser>();
-    private Map<String, Browser> webDriverLookup = new HashMap<String, Browser>();
+    private Map<String, Browser> seleniumLookup = new HashMap<>();
+    private Map<String, Browser> appiumLookup = new HashMap<>();
+    private Map<String, Browser> webDriverLookup = new HashMap<>();
     protected Timestamp lastLookup = null;
     private static final String IEHTA = "iehta";
     private static final String CHROME = "chrome";
@@ -60,7 +60,7 @@ public class BrowserFactory {
         if (shouldRetrieveBrowsers()) {
             browsers = initializeAppiumBrowsers();
         } else {
-            browsers = new ArrayList<Browser>(appiumLookup.values());
+            browsers = new ArrayList<>(appiumLookup.values());
         }
         Collections.sort(browsers);
 
@@ -72,7 +72,7 @@ public class BrowserFactory {
         if (shouldRetrieveBrowsers()) {
             browsers = initializeWebDriverBrowsers();
         } else {
-            browsers = new ArrayList<Browser>(webDriverLookup.values());
+            browsers = new ArrayList<>(webDriverLookup.values());
         }
         Collections.sort(browsers);
 
@@ -85,7 +85,7 @@ public class BrowserFactory {
 
     private List<Browser> initializeAppiumBrowsers() throws JSONException {
         List<Browser> browsers = getAppiumBrowsersFromSauceLabs();
-        appiumLookup = new HashMap<String, Browser>();
+        appiumLookup = new HashMap<>();
         for (Browser browser : browsers) {
             appiumLookup.put(browser.getKey(), browser);
         }
@@ -95,7 +95,7 @@ public class BrowserFactory {
 
     private List<Browser> initializeWebDriverBrowsers() throws JSONException {
         List<Browser> browsers = getWebDriverBrowsersFromSauceLabs();
-        webDriverLookup = new HashMap<String, Browser>();
+        webDriverLookup = new HashMap<>();
         for (Browser browser : browsers) {
             webDriverLookup.put(browser.getKey(), browser);
         }
@@ -127,7 +127,7 @@ public class BrowserFactory {
      * @throws JSONException Invalid JSON
      */
     public List<Browser> getBrowserListFromJson(String browserListJson) throws JSONException {
-        HashMap<String, Browser> browsers = new HashMap<String, Browser>();
+        HashMap<String, Browser> browsers = new HashMap<>();
 
         JSONArray browserArray = new JSONArray(browserListJson);
         for (int i = 0; i < browserArray.length(); i++) {
@@ -184,7 +184,7 @@ public class BrowserFactory {
             }
         }
 
-        return new ArrayList<Browser>(browsers.values());
+        return new ArrayList<>(browsers.values());
     }
 
     private Browser createDeviceBrowser(String seleniumName, String longName, String longVersion, String osName, String device, String deviceType, String shortVersion, String orientation) {

--- a/src/main/java/com/saucelabs/ci/BuildInformation.java
+++ b/src/main/java/com/saucelabs/ci/BuildInformation.java
@@ -29,7 +29,7 @@ public class BuildInformation implements Serializable {
     private int jobsFailed;
     private int jobsErrored;
 
-    final private HashMap<String, Object> changes = new HashMap<String, Object>();
+    final private HashMap<String, Object> changes = new HashMap<>();
 
     /**
      *
@@ -276,6 +276,6 @@ public class BuildInformation implements Serializable {
      * @return map of all the changes
      */
     public Map<String, Object> getChanges() {
-        return new HashMap<String, Object>(changes);
+        return new HashMap<>(changes);
     }
 }

--- a/src/main/java/com/saucelabs/ci/JobInformation.java
+++ b/src/main/java/com/saucelabs/ci/JobInformation.java
@@ -35,7 +35,7 @@ public class JobInformation implements Serializable {
 
     private String failureMessage;
 
-    final private HashMap<String, Object> changes = new HashMap<String, Object>();
+    final private HashMap<String, Object> changes = new HashMap<>();
 
     /**
      *
@@ -375,6 +375,6 @@ public class JobInformation implements Serializable {
      * @return map of all the changes
      */
     public Map<String, Object> getChanges() {
-        return new HashMap<String, Object>(changes);
+        return new HashMap<>(changes);
     }
 }

--- a/src/main/java/com/saucelabs/ci/OperatingSystemDescription.java
+++ b/src/main/java/com/saucelabs/ci/OperatingSystemDescription.java
@@ -19,7 +19,7 @@ enum OperatingSystemDescription {
     private final String key;
     private final String description;
 
-    private static final Map<String, String> descriptionMap = new HashMap<String, String>();
+    private static final Map<String, String> descriptionMap = new HashMap<>();
 
     static {
         for (OperatingSystemDescription operatingSystemDescription : OperatingSystemDescription.values()) {

--- a/src/main/java/com/saucelabs/ci/SODSeleniumConfiguration.java
+++ b/src/main/java/com/saucelabs/ci/SODSeleniumConfiguration.java
@@ -35,7 +35,7 @@ public class SODSeleniumConfiguration
         this.username = username;
         this.accessKey = accessKey;
         this.browser = browser;
-        this.userExtensions = new ArrayList<String>();
+        this.userExtensions = new ArrayList<>();
     }
 
     public String toJson() throws JSONException

--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -37,9 +37,9 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
     /**
      * Contains all the Sauce Connect {@link Process} instances that have been launched.
      */
-    private Map<String, List<Process>> openedProcesses = new HashMap<String, List<Process>>();
+    private Map<String, List<Process>> openedProcesses = new HashMap<>();
 
-    protected Map<String, TunnelInformation> tunnelInformationMap = new ConcurrentHashMap<String, TunnelInformation>();
+    protected Map<String, TunnelInformation> tunnelInformationMap = new ConcurrentHashMap<>();
 
     private SauceREST sauceRest;
 
@@ -378,7 +378,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
             tunnelInformation.setProcess(process);
             List<Process> processes = openedProcesses;
             if (processes == null) {
-                processes = new ArrayList<Process>();
+                processes = new ArrayList<>();
                 this.openedProcesses.put(identifier, processes);
             }
             processes.add(process);

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -103,15 +103,15 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
         }
 
         private static boolean isWindows(String os) {
-            return (os.indexOf("win") >= 0);
+            return os.contains("win");
         }
 
         private static boolean isMac(String os) {
-            return (os.indexOf("mac") >= 0);
+            return os.contains("mac");
         }
 
         private static boolean isUnix(String os) {
-            return (os.indexOf("nux") >= 0);
+            return os.contains("nux");
         }
 
         public String getDirectory(boolean useLatestSauceConnect) {

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -74,30 +74,13 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
          * @return boolean indicating whether OS is 64-bit
          */
         private static boolean is64BitLinux() {
-            BufferedReader reader = null;
             try {
                 Runtime runtime = Runtime.getRuntime();
                 Process process = runtime.exec("uname -a");
                 process.waitFor();
-                reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                StringBuilder builder = new StringBuilder();
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    builder.append(line);
-                }
-                return builder.toString().contains("64");
-            } catch (InterruptedException e) {
+                return IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8).contains("64");
+            } catch (InterruptedException | IOException e) {
                 e.printStackTrace();
-            } catch (IOException e) {
-                e.printStackTrace();
-            } finally {
-                if (reader != null) {
-                    try {
-                        reader.close();
-                    } catch (IOException e1) {
-                        //ignore
-                    }
-                }
             }
             return false;
         }

--- a/src/test/java/com/saucelabs/ci/BrowserFactoryTest.java
+++ b/src/test/java/com/saucelabs/ci/BrowserFactoryTest.java
@@ -2,7 +2,6 @@ package com.saucelabs.ci;
 
 import com.saucelabs.saucerest.SauceREST;
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,11 +29,6 @@ public class BrowserFactoryTest {
             sauceREST.getSupportedPlatforms("webdriver")
         ).thenReturn(IOUtils.toString(this.getClass().getResourceAsStream("/webdriver.json"), UTF_8));
         this.browserFactory = new BrowserFactory(sauceREST);
-    }
-
-    @After
-    public void tearDown() {
-
     }
 
     @Test

--- a/src/test/java/com/saucelabs/ci/BrowserFactoryTest.java
+++ b/src/test/java/com/saucelabs/ci/BrowserFactoryTest.java
@@ -33,12 +33,12 @@ public class BrowserFactoryTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
 
     }
 
     @Test
-    public void testGetAppiumBrowsers() throws Exception {
+    public void testGetAppiumBrowsers() {
         List<Browser> browsers = this.browserFactory.getAppiumBrowsers();
         assertEquals(176, browsers.size());
 
@@ -68,7 +68,7 @@ public class BrowserFactoryTest {
     }
 
     @Test
-    public void testGetWebDriverBrowsers() throws Exception {
+    public void testGetWebDriverBrowsers() {
         List<Browser> browsers = this.browserFactory.getWebDriverBrowsers();
         assertEquals(801, browsers.size());
 
@@ -122,7 +122,7 @@ public class BrowserFactoryTest {
     }
 
     @Test
-    public void testDuplicateMobileDevice() throws Exception {
+    public void testDuplicateMobileDevice() {
         String obj = "{\"deprecated_backend_versions\": [\"1.4.13\"], \"short_version\": \"4.4\", \"long_name\": \"Amazon Kindle Fire HD 8.9 GoogleAPI Emulator\", \"recommended_backend_version\": \"1.5.3\", \"long_version\": \"4.4.\", \"api_name\": \"android\", \"supported_backend_versions\": [\"1.4.16\", \"1.5.1\", \"1.5.2\", \"1.5.3\"], \"device\": \"KindleFireHDGoogleAPI\", \"latest_stable_version\": \"\", \"automation_backend\": \"appium\", \"os\": \"Linux\"}";
 
         List<Browser> browsers = this.browserFactory.getBrowserListFromJson(
@@ -158,7 +158,7 @@ public class BrowserFactoryTest {
     }
 
     @Test
-    public void testDuplicateWebDevice() throws Exception {
+    public void testDuplicateWebDevice() {
         String obj = "{\"short_version\": \"4\", \"long_name\": \"Firefox\", \"api_name\": \"firefox\", \"long_version\": \"4.0.1.\", \"latest_stable_version\": \"\", \"automation_backend\": \"webdriver\", \"os\": \"Linux\"}";
         List<Browser> browsers = this.browserFactory.getBrowserListFromJson(
             "[" + obj + "," + obj + "]"

--- a/src/test/java/com/saucelabs/ci/BuildInformationTest.java
+++ b/src/test/java/com/saucelabs/ci/BuildInformationTest.java
@@ -26,12 +26,12 @@ public class BuildInformationTest {
     }
 
     @Test
-    public void testBuildId() throws Exception {
+    public void testBuildId() {
         assertEquals("1234", build.getBuildId());
     }
 
     @Test
-    public void testStatus() throws Exception {
+    public void testStatus() {
         assertEquals("failed", build.getStatus());
 
         build.clearChanges();
@@ -52,7 +52,7 @@ public class BuildInformationTest {
     }
 
     @Test
-    public void testPopulateFromJson() throws Exception {
+    public void testPopulateFromJson() {
         assertEquals("test-name", build.getName());
 
         jobs = new JSONObject();
@@ -125,7 +125,7 @@ public class BuildInformationTest {
     }
 
     @Test
-    public void testBuildName() throws Exception {
+    public void testBuildName() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("name", "Gavin's first build");
 
@@ -144,7 +144,7 @@ public class BuildInformationTest {
     }
 
     @Test
-    public void testGetChange() throws Exception {
+    public void testGetChange() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("name", "name-name-name");
 

--- a/src/test/java/com/saucelabs/ci/BuildInformationTest.java
+++ b/src/test/java/com/saucelabs/ci/BuildInformationTest.java
@@ -126,7 +126,7 @@ public class BuildInformationTest {
 
     @Test
     public void testBuildName() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("name", "Gavin's first build");
 
         assertEquals("test-name", build.getName());
@@ -145,7 +145,7 @@ public class BuildInformationTest {
 
     @Test
     public void testGetChange() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("name", "name-name-name");
 
         assertEquals("test-name", build.getName());

--- a/src/test/java/com/saucelabs/ci/JobInformationTest.java
+++ b/src/test/java/com/saucelabs/ci/JobInformationTest.java
@@ -25,19 +25,19 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testHMAC() throws Exception {
+    public void testHMAC() {
         assertEquals("hmac", job.getHmac());
         job.setHmac("newhmac");
         assertEquals("newhmac", job.getHmac());
     }
 
     @Test
-    public void testJobId() throws Exception {
+    public void testJobId() {
         assertEquals("1234", job.getJobId());
     }
 
     @Test
-    public void testStatus() throws Exception {
+    public void testStatus() {
         assertEquals("Passed", job.getStatus());
 
         job.clearChanges();
@@ -56,7 +56,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testPopulateFromJson() throws Exception {
+    public void testPopulateFromJson() {
         assertFalse(job.hasJobName());
         assertNull(job.getName());
 
@@ -127,7 +127,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testFailureMessage() throws Exception {
+    public void testFailureMessage() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("failureMessage", "test failure");
 
@@ -147,7 +147,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testJobName() throws Exception {
+    public void testJobName() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("name", "Gavin's first job");
 
@@ -167,7 +167,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testBuildName() throws Exception {
+    public void testBuildName() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("build", "build-name");
 
@@ -190,7 +190,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testBrowser() throws Exception {
+    public void testBrowser() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("browser", "firefox");
 
@@ -206,7 +206,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testVersion() throws Exception {
+    public void testVersion() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("version", "20");
 
@@ -222,7 +222,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testOs() throws Exception {
+    public void testOs() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("os", "20");
 
@@ -248,7 +248,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testVideoUrl() throws Exception {
+    public void testVideoUrl() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("videoUrl", "20");
 
@@ -267,7 +267,7 @@ public class JobInformationTest {
     }
 
     @Test
-    public void testLogUrl() throws Exception {
+    public void testLogUrl() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("logUrl", "20");
 
@@ -287,7 +287,7 @@ public class JobInformationTest {
 
 
     @Test
-    public void testGetChange() throws Exception {
+    public void testGetChange() {
         HashMap<String, Object> updates = new HashMap<String, Object>();
         updates.put("build", "build-name");
         updates.put("name", "name-name-name");

--- a/src/test/java/com/saucelabs/ci/JobInformationTest.java
+++ b/src/test/java/com/saucelabs/ci/JobInformationTest.java
@@ -128,7 +128,7 @@ public class JobInformationTest {
 
     @Test
     public void testFailureMessage() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("failureMessage", "test failure");
 
         assertNull(job.getFailureMessage());
@@ -148,7 +148,7 @@ public class JobInformationTest {
 
     @Test
     public void testJobName() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("name", "Gavin's first job");
 
         assertFalse(job.hasJobName());
@@ -168,7 +168,7 @@ public class JobInformationTest {
 
     @Test
     public void testBuildName() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("build", "build-name");
 
         assertFalse(job.hasBuild());
@@ -191,7 +191,7 @@ public class JobInformationTest {
 
     @Test
     public void testBrowser() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("browser", "firefox");
 
         assertEquals("iexplore", job.getBrowser());
@@ -207,7 +207,7 @@ public class JobInformationTest {
 
     @Test
     public void testVersion() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("version", "20");
 
         assertEquals("10", job.getVersion());
@@ -223,7 +223,7 @@ public class JobInformationTest {
 
     @Test
     public void testOs() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("os", "20");
 
         assertEquals("Windows 7", job.getOs());
@@ -249,7 +249,7 @@ public class JobInformationTest {
 
     @Test
     public void testVideoUrl() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("videoUrl", "20");
 
         assertEquals(
@@ -268,7 +268,7 @@ public class JobInformationTest {
 
     @Test
     public void testLogUrl() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("logUrl", "20");
 
         assertEquals(
@@ -288,7 +288,7 @@ public class JobInformationTest {
 
     @Test
     public void testGetChange() {
-        HashMap<String, Object> updates = new HashMap<String, Object>();
+        HashMap<String, Object> updates = new HashMap<>();
         updates.put("build", "build-name");
         updates.put("name", "name-name-name");
 

--- a/src/test/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManagerTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class AbstractSauceTunnelManagerTest {
 
     @Test
-    public void testGetTunnelIdentifier() throws Exception {
+    public void testGetTunnelIdentifier() {
         assertEquals("missing parameter", "default", AbstractSauceTunnelManager.getTunnelIdentifier("basic -c", "default"));
         assertEquals("basic -i", "basic", AbstractSauceTunnelManager.getTunnelIdentifier("-i basic -c", "default"));
         assertEquals("basic --tunnel-identifier", "basic", AbstractSauceTunnelManager.getTunnelIdentifier("--tunnel-identifier basic -c", "default"));
@@ -22,7 +22,7 @@ public class AbstractSauceTunnelManagerTest {
     }
 
     @Test
-    public void testGetLogfile() throws Exception {
+    public void testGetLogfile() {
         assertNull("missing parameter", AbstractSauceTunnelManager.getLogfile("basic -c"));
         assertEquals("basic -l", "basic", AbstractSauceTunnelManager.getLogfile("-l basic -c"));
         assertEquals("basic --logfile", "basic", AbstractSauceTunnelManager.getLogfile("--logfile basic -c"));
@@ -30,7 +30,7 @@ public class AbstractSauceTunnelManagerTest {
     }
 
     @Test
-    public void testSystemOutGobbler_ProcessLine() throws Exception {
+    public void testSystemOutGobbler_ProcessLine() {
         Semaphore semaphore = new Semaphore(1);
         SauceConnectFourManager man = new SauceConnectFourManager(true);
         AbstractSauceTunnelManager.SystemOutGobbler sot = man.makeOutputGobbler(null, null, semaphore);

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.*;
-import java.net.URISyntaxException;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -29,7 +28,7 @@ public class SauceConnectFourManagerTest {
     private final String STRING_JSON_TUNNELS_ACTIVE;
     private final String STRING_JSON_GET_TUNNEL;
 
-    public SauceConnectFourManagerTest() throws URISyntaxException, IOException {
+    public SauceConnectFourManagerTest() throws IOException {
         STRING_JSON_TUNNELS_ACTIVE = IOUtils.toString(getClass().getResourceAsStream("/tunnels_active_tunnel.json"), "UTF-8");
         STRING_JSON_TUNNELS_EMPTY = IOUtils.toString(getClass().getResourceAsStream("/tunnels_empty.json"), "UTF-8");
         STRING_JSON_GET_TUNNEL = IOUtils.toString(getClass().getResourceAsStream("/single_tunnel.json"), "UTF-8");
@@ -47,7 +46,7 @@ public class SauceConnectFourManagerTest {
     }
 
     @After
-    public void teardown() throws Exception {
+    public void teardown() {
         verifyNoMoreInteractions(mockSauceRest);
         verify(tunnelManager, times(1)).setSauceRest(mockSauceRest);
     }

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
@@ -82,8 +82,6 @@ public class SauceConnectFourManagerTest {
                 null, "", ps, false,
                 ""
             );
-        } catch (Exception e) {
-            throw e;
         } finally {
             verify(mockSauceRest).getTunnels();
             verify(tunnelManager).createProcess(

--- a/src/test/java/com/saucelabs/sod/BrowserTest.java
+++ b/src/test/java/com/saucelabs/sod/BrowserTest.java
@@ -19,7 +19,7 @@ public class BrowserTest  {
     private SauceREST sauceREST = new SauceREST(null, null);
 
     @Test
-    public void testNames() throws Exception {
+    public void testNames() {
         Browser browser = new Browser(null, null, null, null, null, null, "Windows 2008");
         assertEquals("windows 2008 is really windows 7", browser.getName(), "Windows 7");
         browser = new Browser(null, null, null, null, null, null, "Windows 2003");
@@ -37,7 +37,7 @@ public class BrowserTest  {
     }
 
     @Test
-    public void browserFromSaucelabs() throws Exception {
+    public void browserFromSaucelabs() {
         BrowserFactory factory = new BrowserFactory(sauceREST);
         List<Browser> browsers = factory.getWebDriverBrowsers();
         assertFalse("browsers is empty", browsers.isEmpty());
@@ -47,7 +47,7 @@ public class BrowserTest  {
 
 
     @Test
-    public void copyBrowser() throws Exception {
+    public void copyBrowser() {
         Browser orig = new Browser("thisismykey", "Windows 2008", "Firefox", "Mozilla Firefox", "47.0.12345", "47", "firefox");
         Browser browser = new Browser(orig, false);
         Browser latest = new Browser(orig, true);

--- a/src/test/java/com/saucelabs/sod/ExtractFiles.java
+++ b/src/test/java/com/saucelabs/sod/ExtractFiles.java
@@ -1,7 +1,6 @@
 package com.saucelabs.sod;
 
 import com.saucelabs.ci.sauceconnect.SauceConnectFourManager;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -12,11 +11,6 @@ import java.io.File;
 public class ExtractFiles {
 
     private SauceConnectFourManager manager = new SauceConnectFourManager();
-
-    @Before
-    public void setup() {
-
-    }
 
     @Test
     public void linux() throws Exception {

--- a/src/test/java/com/saucelabs/sod/ExtractFiles.java
+++ b/src/test/java/com/saucelabs/sod/ExtractFiles.java
@@ -14,7 +14,7 @@ public class ExtractFiles {
     private SauceConnectFourManager manager = new SauceConnectFourManager();
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
 
     }
 


### PR DESCRIPTION
 - Remove redundant "throws" clauses
 - Replace explicit type declarations with dimaond operators
 - Remove empty @Before/@After methods from unit tests
 - Replace String#indexOf with String#contains
 - Remove redundant "catch" section
 - Use Apache commons IOUtils to read process input stream
