### PR TITLE
Trim whitespace on options string

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -232,7 +232,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
         args = addElement(args, "-P");
         args = addElement(args, String.valueOf(port));
         if (StringUtils.isNotBlank(options)) {
-            args = addElement(args, options);
+            args = addElement(args, options.trim());
         }
         return args;
     }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -231,7 +231,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
         args = addElement(args, apiKey);
         args = addElement(args, "-P");
         args = addElement(args, String.valueOf(port));
-        if (StringUtils.isNotBlank(options)) {
+        if (StringUtils.isNotBlank(options.trim())) {
             args = addElement(args, options.trim());
         }
         return args;


### PR DESCRIPTION
This was causing an empty string to be added to the command line
arguments, which Sauce Connect 4.6+ treats as an error.