### PR TITLE
[PERF-2671] Upgrade plexus-archiver as old ones dependency has securi…

### DIFF
--- a/ CHANGELOG.md
+++ b/ CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 1.147
+### Changed
+- Updated dependencies
+
+
+### Security
+- plexus-archiver was updated, because it contained vulnerable dependency: org.apache.commons:commons-compress:1.16.1

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>3.4</version>
+            <version>4.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mockito.version>1.10.19</mockito.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13</junit.version>
         <github.global.server>github</github.global.server>
         <github.global.oauth2Token>${env.GH_TOKEN}</github.global.oauth2Token>
         <java.level>7</java.level>
@@ -104,7 +104,7 @@
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.5</version>
+                        <version>1.11.2</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -244,26 +244,26 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.10</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.0.42</version>
+            <version>1.0.44</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20171018</version>
+            <version>20200518</version>
             <scope>compile</scope>
         </dependency>
 
@@ -279,7 +279,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>
@@ -298,7 +298,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-container-default</artifactId>
-            <version>1.5.5</version>
+            <version>2.1.0</version>
         </dependency>
 
 


### PR DESCRIPTION
…ty issue

Attlasian raise a security issue for sauce bamboo plugin which uses this repo as dependency. Issues exist for org.apache.commons:commons-compress:1.16.1 which is a dependency of older plexus-archiver.