### PR TITLE
Remove useless catch-throw exception block

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -383,12 +383,6 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
             }
             processes.add(process);
             return process;
-        } catch (SauceConnectException e) {
-            throw e;
-        } catch (IOException e) {
-            //thrown if an error occurs starting the process builder
-            julLogger.log(Level.WARNING, "Exception occurred during invocation of Sauce Connect", e);
-            throw new SauceConnectException(e);
         } finally {
             //release the access lock
             tunnelInformation.getLock().unlock();


### PR DESCRIPTION
1.
```java
catch (IOException e) {
    //thrown if an error occurs starting the process builder
    julLogger.log(Level.WARNING, "Exception occurred during invocation of Sauce Connect", e);
    throw new SauceConnectException(e);
}
```
is unreachable because previous `catch` block handles all `SauceConnectException`-s and at the same time no `IOException` is thrown in `try` block
2. 
```java
catch (SauceConnectException e) {
    throw e;
}
```
doesn't make sense, because it catches the exception and immediately re-throws it