### PR TITLE
Fix handling of spaces in SauceConnect CLI arguments

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -205,13 +205,13 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      */
     protected String[] addElement(String[] original, String added) {
         //split added on space
-        String[] split = added.split(" ");
-        String[] result = original;
-        for (String arg : split) {
-            String[] newResult = Arrays.copyOf(result, result.length + 1);
-            newResult[result.length] = arg;
-            result = newResult;
-        }
+        String[] split = StringUtils.split(added, ' ');
+        return joinArgs(original, split);
+    }
+
+    protected String[] joinArgs(String[] initial, String... toAdd) {
+        String[] result = Arrays.copyOf(initial, initial.length + toAdd.length);
+        System.arraycopy(toAdd, 0, result, initial.length, toAdd.length);
         return result;
     }
 

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -264,16 +264,9 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
      * @return String array representing the command line args to be used to launch Sauce Connect
      */
     protected String[] generateSauceConnectArgs(String[] args, String username, String apiKey, int port, String options) {
-        args = addElement(args, "-u");
-        args = addElement(args, username);
-        args = addElement(args, "-k");
-        args = addElement(args, apiKey);
-        args = addElement(args, "-P");
-        args = addElement(args, String.valueOf(port));
-        if (StringUtils.isNotBlank(options.trim())) {
-            args = addElement(args, options.trim());
-        }
-        return args;
+        String[] result = joinArgs(args, "-u", username.trim(), "-k", apiKey.trim(), "-P", String.valueOf(port));
+        result = addElement(result, options);
+        return result;
     }
 
     /**


### PR DESCRIPTION
The aim of this PR is to make processing of spaces in SC CLI arguments more user-friendly. SC  fails to start when an empty argument is present:
```
Error: unknown command "" for "sc"
Usage:
  sc [flags]

Flags:
  -k, --api-key string                Sauce Labs API Key.
  -a, --auth strings                  Perform basic authentication when an URL on <host:port> asks for a username and password.
...
```
This PR:
- fixes the processing of duplicate spaces [in `options` string](https://github.com/saucelabs/ci-sauce/blob/cb97b7bc3af822b01676dd65263acd494b1eb851/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java#L171)
- trims wrapping spaces in [`username` and `apiKey` parameters](https://github.com/saucelabs/ci-sauce/blob/cb97b7bc3af822b01676dd65263acd494b1eb851/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java#L171)