### PR TITLE
Remove unreachable code

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -423,10 +423,6 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      * @return String the internal Sauce tunnel id
      */
     private String activeTunnelIdentifier(String username, String identifier) {
-        if (sauceRest == null) {
-            //TODO how to handle?
-            return null;
-        }
         try {
             JSONArray tunnelArray = new JSONArray(sauceRest.getTunnels());
             if (tunnelArray.length() == 0) {


### PR DESCRIPTION
The removed piece of code is unreachable. `sauceRest` is initialized prior to invocation of `activeTunnelIdentifier` method
https://github.com/saucelabs/ci-sauce/blob/bec624a3f869dbce40ebcb627b3b3e59bc66d249/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java#L270-L273