### PR TITLE
Handle EU datacenter tunnel shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.8</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -270,7 +270,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws SauceConnectException thrown if an error occurs launching Sauce Connect
      */
-    public Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
+    public Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options, PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
         return openConnection(username, apiKey, "US", port, sauceConnectJar, options, printStream, verboseLogging, sauceConnectPath);
     }
 
@@ -289,7 +289,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws SauceConnectException thrown if an error occurs launching Sauce Connect
      */
-    public Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
+    public Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options, PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
 
         //ensure that only a single thread attempts to open a connection
         if (sauceRest == null) {

--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -257,6 +257,24 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
     }
 
     /**
+     * Creates a new process to run Sauce Connect on the US Data Center
+     *
+     * @param username         the name of the Sauce OnDemand user
+     * @param apiKey           the API Key for the Sauce OnDemand user
+     * @param port             the port which Sauce Connect should be run on
+     * @param sauceConnectJar  the Jar file containing Sauce Connect.  If null, then we attempt to find Sauce Connect from the classpath (only used by SauceConnectTwoManager)
+     * @param options          the command line options to pass to Sauce Connect
+     * @param printStream      A print stream in which to redirect the output from Sauce Connect to.  Can be null
+     * @param verboseLogging   indicates whether verbose logging should be output
+     * @param sauceConnectPath if defined, Sauce Connect will be launched from the specified path and won't be extracted from the jar file
+     * @return a {@link Process} instance which represents the Sauce Connect instance
+     * @throws SauceConnectException thrown if an error occurs launching Sauce Connect
+     */
+    public Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
+        return openConnection(username, apiKey, "US", port, sauceConnectJar, options, printStream, verboseLogging, sauceConnectPath);
+    }
+
+    /**
      * Creates a new process to run Sauce Connect.
      *
      * @param username         the name of the Sauce OnDemand user

--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -261,6 +261,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      *
      * @param username         the name of the Sauce OnDemand user
      * @param apiKey           the API Key for the Sauce OnDemand user
+     * @param dataCenter       the Sauce Labs DataCenter name (US, EU, US_EAST)
      * @param port             the port which Sauce Connect should be run on
      * @param sauceConnectJar  the Jar file containing Sauce Connect.  If null, then we attempt to find Sauce Connect from the classpath (only used by SauceConnectTwoManager)
      * @param options          the command line options to pass to Sauce Connect
@@ -270,11 +271,11 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws SauceConnectException thrown if an error occurs launching Sauce Connect
      */
-    public Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
+    public Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
 
         //ensure that only a single thread attempts to open a connection
         if (sauceRest == null) {
-            sauceRest = new SauceREST(username, apiKey);
+            sauceRest = new SauceREST(username, apiKey, dataCenter);
         }
         String name = getTunnelName(options, username);
         TunnelInformation tunnelInformation = getTunnelInformation(name);
@@ -347,7 +348,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
                             launchAttempts.incrementAndGet();
 
                             //call openConnection again to see if the process has closed
-                            return openConnection(username, apiKey, port, sauceConnectJar, options, printStream, verboseLogging, sauceConnectPath);
+                            return openConnection(username, apiKey, dataCenter, port, sauceConnectJar, options, printStream, verboseLogging, sauceConnectPath);
                         } else {
                             //we've tried relaunching Sauce Connect 3 times
                             throw new SauceConnectDidNotStartException("Unable to start Sauce Connect, please see the Sauce Connect log");

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
@@ -26,6 +26,7 @@ public interface SauceTunnelManager {
      *
      * @param username         the name of the Sauce OnDemand user
      * @param apiKey           the API Key for the Sauce OnDemand user
+     * @param dataCenter       the Sauce Labs Data Center name (US, EU, US_EAST)
      * @param port             the port which Sauce Connect should be run on
      * @param sauceConnectJar  the Jar file containing Sauce Connect.  If null, then we attempt to find Sauce Connect from the classpath (only used by SauceConnectTwoManager)
      * @param options          the command line options to pass to Sauce Connect
@@ -35,6 +36,6 @@ public interface SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws IOException thrown if an error occurs launching Sauce Connect
      */
-    Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
+    Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options,PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
 
 }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
@@ -35,7 +35,7 @@ public interface SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws IOException thrown if an error occurs launching Sauce Connect
      */
-    Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
+    Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options, PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
 
     /**
      * Creates a new process to run Sauce Connect.
@@ -52,6 +52,6 @@ public interface SauceTunnelManager {
      * @return a {@link Process} instance which represents the Sauce Connect instance
      * @throws IOException thrown if an error occurs launching Sauce Connect
      */
-    Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options,PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
+    Process openConnection(String username, String apiKey, String dataCenter, int port, File sauceConnectJar, String options, PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
 
 }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceTunnelManager.java
@@ -22,6 +22,22 @@ public interface SauceTunnelManager {
     void closeTunnelsForPlan(String username, String options, PrintStream printStream);
 
     /**
+     * Creates a new process to run Sauce Connect in the US Data Center
+     *
+     * @param username         the name of the Sauce OnDemand user
+     * @param apiKey           the API Key for the Sauce OnDemand user
+     * @param port             the port which Sauce Connect should be run on
+     * @param sauceConnectJar  the Jar file containing Sauce Connect.  If null, then we attempt to find Sauce Connect from the classpath (only used by SauceConnectTwoManager)
+     * @param options          the command line options to pass to Sauce Connect
+     * @param printStream      A print stream in which to redirect the output from Sauce Connect to.  Can be null
+     * @param verboseLogging   indicates whether verbose logging should be output
+     * @param sauceConnectPath if defined, Sauce Connect will be launched from the specified path and won't be extracted from the jar file
+     * @return a {@link Process} instance which represents the Sauce Connect instance
+     * @throws IOException thrown if an error occurs launching Sauce Connect
+     */
+    Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws IOException;
+
+    /**
      * Creates a new process to run Sauce Connect.
      *
      * @param username         the name of the Sauce OnDemand user

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
@@ -93,14 +93,15 @@ public class SauceConnectFourManagerTest {
     }
 
     private Process testOpenConnection(String logFile, String username) throws IOException {
-        String apiKey = "fakeapikey";
-        int port = 12345;
+        final String apiKey = "fakeapikey";
+        final int port = 12345;
+        final String dataCenter = "US";
 
         try (InputStream resourceAsStream = getResourceAsStream(logFile)) {
             when(mockProcess.getErrorStream()).thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
             when(mockProcess.getInputStream()).thenReturn(resourceAsStream);
             doReturn(mockProcess).when(tunnelManager).createProcess(any(String[].class), any(File.class));
-            return tunnelManager.openConnection(username, apiKey, port, null, "  ", ps, false, "");
+            return tunnelManager.openConnection(username, apiKey, dataCenter, port, null, "  ", ps, false, "");
         } finally {
             verify(mockSauceRest).getTunnels();
             ArgumentCaptor<String[]> argsCaptor = ArgumentCaptor.forClass(String[].class);


### PR DESCRIPTION
The `openConnection()` function didn't take a dataCenter argument, so it never stored that information when the tunnel shuts down later.

This PR adds a new parameter to `openConnection()`, and adds a wrapper function to provide backwards compatibility.