### PR TITLE
adding escapes to extra info

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -255,7 +255,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
     }
 
     protected String[] addExtraInfo(String[] args) {
-        String[] result = joinArgs(args, "--extra-info", "{\"runner\": \"jenkins\"}");
+        String[] result = joinArgs(args, "--extra-info", "{\\\"runner\\\": \\\"jenkins\\\"}");
         return result;
     }
 

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
@@ -114,7 +114,7 @@ public class SauceConnectFourManagerTest {
             assertEquals("-P", actualArgs[5]);
             assertEquals(Integer.toString(port), actualArgs[6]);
             assertEquals("--extra-info", actualArgs[7]);
-            assertEquals("{\"runner\": \"jenkins\"}", actualArgs[8]);
+            assertEquals("{\\\"runner\\\": \\\"jenkins\\\"}", actualArgs[8]);
         }
     }
 
@@ -141,7 +141,7 @@ public class SauceConnectFourManagerTest {
             assertEquals("-P", actualArgs[5]);
             assertEquals(Integer.toString(port), actualArgs[6]);
             assertEquals("--extra-info", actualArgs[7]);
-            assertEquals("{\"runner\": \"jenkins\"}", actualArgs[8]);
+            assertEquals("{\\\"runner\\\": \\\"jenkins\\\"}", actualArgs[8]);
         }
     }
 


### PR DESCRIPTION
This PR addresses #131. I have only tested this on a Windows 10 Jenkins Agent. It may not be an issue on Linux, but without the additional escapes, the `extra info is not valid JSON` message consistently displays/prevents Sauce Connect from starting.

The better solution for this might be to expose extra-info as a constructor parameter.