### PR TITLE
Catch NPE with sauceRest.deleteTunnel()

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -80,12 +80,17 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
                 closeSauceConnectProcess(printStream, sauceConnect);
                 String tunnelId = tunnelInformation.getTunnelId();
                 if (tunnelId != null && sauceRest != null) {
+                    logMessage(printStream, "Stopping Sauce Connect tunnel: " + tunnelId);
                     //forcibly delete tunnel
                     try {
                         sauceRest.deleteTunnel(tunnelId);
+                        logMessage(printStream, "Deleted tunnel");
                     }
                     catch (java.io.IOException e) {
                         logMessage(printStream, "Error during tunnel removal: " + e);
+                    }
+                    catch (NullPointerException e) {
+                        logMessage(printStream, "Error connecting to REST API: " + e);
                     }
                 }
                 tunnelInformationMap.remove(tunnelName);


### PR DESCRIPTION
A failure to delete a tunnel shouldn't cause a job to fail - the tunnel will be cleaned up later when idle.