### PR TITLE
Remove duplicate logging to `System.out`

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -548,7 +548,6 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
                 if (printStream != null) {
                     printStream.println(line);
                 }
-                System.out.println(line);
                 julLogger.info(line);
             }
         }


### PR DESCRIPTION
No need to log into `System.out` once next line of code does logging via JUL which can be confgured to log into various targets including console.