### PR TITLE
Bump `com.saucelabs:saucerest` from `2.0.2` to `2.0.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
`com.saucelabs:saucerest:2.0.3` includes important [fix](https://github.com/saucelabs/saucerest-java/pull/314).