### PR TITLE
Add LINUX_ARM64 support in unarchiver logic

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -279,7 +279,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager implemen
         AbstractUnArchiver unArchiver;
         if (operatingSystem == OperatingSystem.OSX || operatingSystem == OperatingSystem.WINDOWS) {
             unArchiver = new ZipUnArchiver();
-        } else if (operatingSystem == OperatingSystem.LINUX) {
+        } else if (operatingSystem == OperatingSystem.LINUX || operatingSystem == OperatingSystem.LINUX_ARM64) {
             removeOldTarFile(zipFile);
             unArchiver = new TarGZipUnArchiver();
         } else {


### PR DESCRIPTION
ARM64 based Linux systems are throwing `Unknown operating system: LINUX_ARM64` in our jenkins agents.

Used in [jenkins-sauceondemand-plugin](https://github.com/jenkinsci/sauce-ondemand-plugin). I've tested the plugin with this change and it detects the operating system properly.