### PR TITLE
Use logging facade SLF4J instead of JDK Logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,9 +273,9 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
+      <artifactId>slf4j-api</artifactId>
       <version>2.0.9</version>
-      <scope>runtime</scope>
+      <scope>compile</scope>
     </dependency>
 
 

--- a/src/main/java/com/saucelabs/ci/BrowserFactory.java
+++ b/src/main/java/com/saucelabs/ci/BrowserFactory.java
@@ -7,12 +7,12 @@ import com.saucelabs.saucerest.model.platform.Platform;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.*;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Handles invoking the Sauce REST API to retrieve the list of valid Browsers. The list of browser
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
  */
 public class BrowserFactory {
 
-  private static final Logger logger = Logger.getLogger(BrowserFactory.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrowserFactory.class);
 
   public static final int ONE_HOUR_IN_MILLIS = 1000 * 60 * 60;
 
@@ -50,7 +50,7 @@ public class BrowserFactory {
       initializeWebDriverBrowsers();
       initializeAppiumBrowsers();
     } catch (JSONException | IOException e) {
-      logger.log(Level.WARNING, "Error retrieving browsers, attempting to continue", e);
+      LOGGER.warn("Error retrieving browsers, attempting to continue", e);
     }
   }
 

--- a/src/main/java/com/saucelabs/ci/SODSeleniumConfiguration.java
+++ b/src/main/java/com/saucelabs/ci/SODSeleniumConfiguration.java
@@ -5,11 +5,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * @author <a href="http://www.sysbliss.com">Jonathan Doklovic</a>
@@ -17,7 +17,7 @@ import java.util.logging.Logger;
  */
 @Deprecated
 public class SODSeleniumConfiguration {
-  private static final Logger logger = Logger.getLogger(SODSeleniumConfiguration.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(SODSeleniumConfiguration.class);
 
   private String username;
   private String accessKey;
@@ -157,7 +157,7 @@ public class SODSeleniumConfiguration {
         this.userExtensions.add(ext);
       } catch (JSONException e) {
         // just print and ignore
-        logger.log(Level.WARNING, "Error parsing JSON string", e);
+        LOGGER.warn("Error parsing JSON string", e);
       }
     }
   }
@@ -168,7 +168,7 @@ public class SODSeleniumConfiguration {
         setUserExtensions(new JSONArray(jsonString));
       } catch (JSONException e) {
         // just print and ignore
-        logger.log(Level.WARNING, "Error parsing JSON string", e);
+        LOGGER.warn("Error parsing JSON string", e);
       }
     }
   }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -19,11 +19,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provides common logic for the invocation of Sauce Connect v3 and v4 processes. The class
@@ -34,9 +35,7 @@ import org.json.JSONException;
  */
 public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
 
-  /** Logger instance. */
-  protected static final java.util.logging.Logger julLogger =
-      java.util.logging.Logger.getLogger(AbstractSauceTunnelManager.class.getName());
+  protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractSauceTunnelManager.class);
 
   /** Should Sauce Connect output be suppressed? */
   protected boolean quietMode;
@@ -227,7 +226,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
     if (printStream != null) {
       printStream.println(message);
     }
-    julLogger.log(Level.INFO, message);
+    LOGGER.info(message);
   }
 
   /**
@@ -533,7 +532,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
         }
       } catch (InterruptedException e) {
         // continue;
-        julLogger.log(Level.WARNING, "Exception occurred during invocation of Sauce Connect", e);
+        LOGGER.warn("Exception occurred during invocation of Sauce Connect", e);
       }
 
       incrementProcessCountForUser(tunnelInformation, printStream);
@@ -600,7 +599,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
       }
     } catch (JSONException | IOException e) {
       // log error and return false
-      julLogger.log(Level.WARNING, "Exception occurred retrieving tunnel information", e);
+      LOGGER.warn("Exception occurred retrieving tunnel information", e);
     }
     return null;
   }
@@ -693,7 +692,7 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
         if (printStream != null) {
           printStream.println(line);
         }
-        julLogger.info(line);
+        LOGGER.info(line);
       }
     }
   }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.logging.Level;
 
 import java.net.URL;
 
@@ -204,12 +203,7 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager
       args = generateSauceConnectArgs(args, username, apiKey, port, options);
       args = addExtraInfo(args);
 
-      julLogger.log(
-          Level.INFO,
-          "Launching Sauce Connect "
-              + getCurrentVersion()
-              + " "
-              + hideSauceConnectCommandlineSecrets(args));
+      LOGGER.info("Launching Sauce Connect {} {}", getCurrentVersion(), hideSauceConnectCommandlineSecrets(args));
       return createProcess(args, sauceConnectBinary.getParentFile());
     } catch (IOException e) {
       throw new SauceConnectException(e);


### PR DESCRIPTION
Technically saying `ci-sauce` is a SauceConenct management library (despite its naming). In other words it is not used as a standalone application, it's used as dependency for other libraries/applications/CI_plugins. That's why `ci-sauce` shouldn't have tight coupling with any logging framework (even JDK logger), it should rely on logging facade (SLF4J) instead.

