### PR TITLE
Replace `plexus-archiver` with Apache `commons-compress`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,9 +255,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>4.9.0</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.24.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/test/java/com/saucelabs/sod/ExtractFiles.java
+++ b/src/test/java/com/saucelabs/sod/ExtractFiles.java
@@ -1,27 +1,42 @@
 package com.saucelabs.sod;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import com.saucelabs.ci.sauceconnect.SauceConnectFourManager;
-import org.junit.jupiter.api.Test;
+import com.saucelabs.ci.sauceconnect.SauceConnectFourManager.OperatingSystem;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.stream.Stream;
 
 /**
  * @author Ross Rowe
  */
 class ExtractFiles {
 
-  private SauceConnectFourManager manager = new SauceConnectFourManager();
+  private final SauceConnectFourManager manager = new SauceConnectFourManager();
 
-  @Test
-  void linux() throws Exception {
-
-    File workingDirectory = new File(System.getProperty("java.io.tmpdir"));
-    manager.extractZipFile(workingDirectory, SauceConnectFourManager.OperatingSystem.LINUX);
+  static Stream<Arguments> operatingSystems() {
+    return Stream.of(
+      arguments(OperatingSystem.OSX, "sc"),
+      arguments(OperatingSystem.LINUX, "sc"),
+      arguments(OperatingSystem.LINUX_ARM64, "sc"),
+      arguments(OperatingSystem.WINDOWS, "sc.exe")
+    );
   }
 
-  @Test
-  void windows() throws Exception {
-    File workingDirectory = new File(System.getProperty("java.io.tmpdir"));
-    manager.extractZipFile(workingDirectory, SauceConnectFourManager.OperatingSystem.WINDOWS);
+  @ParameterizedTest
+  @MethodSource("operatingSystems")
+  void shouldExtractSauceConnectExecutable(OperatingSystem os, String executableFileName, @TempDir Path tempDir)
+      throws IOException {
+    File dir = manager.extractZipFile(tempDir.toFile(), os);
+    File executableFile = dir.toPath().resolve("bin/" + executableFileName).toFile();
+    assertTrue(executableFile.exists());
   }
 }


### PR DESCRIPTION
Reasons:
 - to reduce memory footprint: `plexus-archiver` is based on  Apache `commons-compress` and includes set of other [dependencies](https://codehaus-plexus.github.io/plexus-archiver/dependencies.html)
 - `plexus-archiver` supports [wide range](https://codehaus-plexus.github.io/plexus-archiver/index.html) of archive formats, but they are not needed, as `ci-sauce` works only with 2 formats: `zip` and `tar.gz`
 - to optimize performance (less I/O operations):
   - `tar`-file is not created anymore while extracting `tar.gz` file
   - the archive file is not_downloaded_from_remote-storage/not_extracted_from_jar to the file system, extracting of the archive file is done on the fly