### PR TITLE
Add ability to set custom runner in CLI args

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManager.java
@@ -39,6 +39,9 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager
   /** Remove all created files and directories on exit */
   private boolean cleanUpOnExit;
 
+  /** System which runs SauceConnect, this info is added to '--extra-info' argument */
+  private final String runner;
+
   /** Represents the operating system-specific Sauce Connect binary. */
   public enum OperatingSystem {
     OSX("osx", "zip", null, UNIX_TEMP_DIR),
@@ -141,12 +144,32 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager
   }
 
   /**
+   * Constructs a new instance with quiet mode disabled.
+   *
+   * @param runner System which runs SauceConnect, this info is added to '--extra-info' argument
+   */
+  public SauceConnectFourManager(String runner) {
+    this(false, runner);
+  }
+
+  /**
    * Constructs a new instance.
    *
    * @param quietMode indicates whether Sauce Connect output should be suppressed
    */
   public SauceConnectFourManager(boolean quietMode) {
+    this(quietMode, "jenkins");
+  }
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param quietMode indicates whether Sauce Connect output should be suppressed
+   * @param runner System which runs SauceConnect, this info is added to '--extra-info' argument
+   */
+  public SauceConnectFourManager(boolean quietMode, String runner) {
     super(quietMode);
+    this.runner = runner;
   }
 
   /**
@@ -285,9 +308,9 @@ public class SauceConnectFourManager extends AbstractSauceTunnelManager
     String[] result;
     OperatingSystem operatingSystem = OperatingSystem.getOperatingSystem();
     if (operatingSystem == OperatingSystem.WINDOWS) {
-      result = joinArgs(args, "--extra-info", "{\\\"runner\\\": \\\"jenkins\\\"}");
+      result = joinArgs(args, "--extra-info", "{\\\"runner\\\": \\\"" + runner + "\\\"}");
     } else {
-      result = joinArgs(args, "--extra-info", "{\"runner\": \"jenkins\"}");
+      result = joinArgs(args, "--extra-info", "{\"runner\": \"" + runner + "\"}");
     }
     return result;
   }

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectFourManagerTest.java
@@ -40,7 +40,7 @@ class SauceConnectFourManagerTest {
   @Mock private Process mockProcess;
   @Mock private SauceREST mockSauceRest;
   @Mock private SauceConnectEndpoint mockSCEndpoint;
-  @Spy private final SauceConnectFourManager tunnelManager = new SauceConnectFourManager(false);
+  @Spy private final SauceConnectFourManager tunnelManager = new SauceConnectFourManager();
 
   private final PrintStream ps = System.out;
 


### PR DESCRIPTION
# One-line summary

Add ability to set custom `runner` in `--extra-info` CLI argument.

## Description
The library is used not only by Jenkins plugin, and hardcoded `runner` doesn't reflect the way, how SC is run. This PR adds the ability to configure `runner`.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Configuration change
- [ ] Refactor/improvements
- [ ] Documentation / non-code

## Tasks
_List of tasks you will do to complete the PR_
  - [ ] Created Task 1
  - [ ] Created Task 2
  - [ ] To-do Task 3

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
