### PR TITLE
Remove apiPort from class state in order to avoid concurrency issues

### DIFF
--- a/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/AbstractSauceTunnelManager.java
@@ -747,18 +747,6 @@ public abstract class AbstractSauceTunnelManager implements SauceTunnelManager {
 
   protected abstract String getCurrentVersion();
 
-  /**
-   * Returns the arguments to be used to launch Sauce Connect
-   *
-   * @param args the initial Sauce Connect command line args
-   * @param username name of the user which launched Sauce Connect
-   * @param apiKey the access key for the Sauce user
-   * @param options command line args specified by the user
-   * @return String array representing the command line args to be used to launch Sauce Connect
-   */
-  protected abstract String[] generateSauceConnectArgs(
-      String[] args, String username, String apiKey, String options);
-
   protected abstract String[] addExtraInfo(String[] args);
 
   /**

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectManager.java
@@ -140,21 +140,9 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
   private static final String SAUCE_CONNECT_PREFIX = "sauce-connect-";
   public static final String SAUCE_CONNECT = SAUCE_CONNECT_PREFIX + CURRENT_SC_VERSION;
 
-  private static final int DEFAULT_API_PORT = 9000;
-  private int apiPort;
-
   /** Constructs a new instance with quiet mode disabled. */
   public SauceConnectManager() {
     this(false);
-  }
-
-  /**
-   * Constructs a new instance with quiet mode disabled.
-   *
-   * @param runner System which runs SauceConnect, this info is added to '--metadata runner=' argument
-   */
-  public SauceConnectManager(String runner) {
-    this(false, runner, DEFAULT_API_PORT);
   }
 
   /**
@@ -163,7 +151,7 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
    * @param quietMode indicates whether Sauce Connect output should be suppressed
    */
   public SauceConnectManager(boolean quietMode) {
-    this(quietMode, "jenkins", DEFAULT_API_PORT);
+    this(quietMode, "jenkins");
   }
 
   /**
@@ -171,12 +159,10 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
    *
    * @param quietMode indicates whether Sauce Connect output should be suppressed
    * @param runner System which runs SauceConnect, this info is added to '--metadata runner=' argument
-   * @param apiPort Port the Sauce Connect process will listen on
    */
-  public SauceConnectManager(boolean quietMode, String runner, int apiPort) {
+  public SauceConnectManager(boolean quietMode, String runner) {
     super(quietMode);
     this.runner = runner;
-    this.apiPort = apiPort;
   }
 
   /**
@@ -241,17 +227,13 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
         }
       }
 
-      if ( apiPort != 0 ) {
-        this.apiPort = apiPort;
-      }
-
       // although we are setting the working directory, we need to specify the full path to the exe
       String[] args = {sauceConnectBinary.getPath()};
       if (legacy) {
-          args = generateSauceConnectArgsLegacy(args, username, accessKey, options);
+          args = generateSauceConnectArgsLegacy(args, username, accessKey, apiPort, options);
           args = addExtraInfoLegacy(args);
       } else {
-          args = generateSauceConnectArgs(args, username, accessKey, options);
+          args = generateSauceConnectArgs(args, username, accessKey, apiPort, options);
           args = addExtraInfo(args);
       }
 
@@ -342,13 +324,14 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
    * @param args the initial Sauce Connect command line args
    * @param username name of the user which launched Sauce Connect
    * @param accessKey the access key for the Sauce user
+   * @param apiPort specify the port the Sauce Connect API will listen on
    * @param options command line args specified by the user
    * @return String array representing the command line args to be used to launch Sauce Connect
    */
   protected String[] generateSauceConnectArgs(
-      String[] args, String username, String accessKey, String options) {
+      String[] args, String username, String accessKey, int apiPort, String options) {
     String[] result =
-        joinArgs(args, "run", "--username", username.trim(), "--access-key", accessKey.trim(), "--api-address", ":" + String.valueOf(this.apiPort));
+        joinArgs(args, "run", "--username", username.trim(), "--access-key", accessKey.trim(), "--api-address", ":" + String.valueOf(apiPort));
     result = addElement(result, options);
     return result;
   }
@@ -362,15 +345,16 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
    * @param args the initial Sauce Connect command line args
    * @param username name of the user which launched Sauce Connect
    * @param accessKey the access key for the Sauce user
+   * @param apiPort specify the port the Sauce Connect API will listen on
    * @param options command line args specified by the user
    * @return String array representing the command line args to be used to launch Sauce Connect
    */
   @Deprecated
   protected String[] generateSauceConnectArgsLegacy(
-      String[] args, String username, String accessKey, String options) {
+      String[] args, String username, String accessKey, int apiPort, String options) {
     String[] result;
 
-    result = joinArgs(args, "legacy", "--user", username.trim(), "--api-key", accessKey.trim(), "--status-address", "0.0.0.0:" + String.valueOf(this.apiPort));
+    result = joinArgs(args, "legacy", "--user", username.trim(), "--api-key", accessKey.trim(), "--status-address", "0.0.0.0:" + String.valueOf(apiPort));
     result = addElement(result, options);
     return result;
   }

--- a/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectManager.java
+++ b/src/main/java/com/saucelabs/ci/sauceconnect/SauceConnectManager.java
@@ -441,22 +441,6 @@ public class SauceConnectManager extends AbstractSauceTunnelManager implements S
     return new File(workingDirectory, operatingSystem.getDirectory(useLatestSauceConnect));
   }
 
-  protected boolean isConnected() {
-    HttpClient client = HttpClient.newHttpClient();
-
-    HttpRequest request = HttpRequest.newBuilder()
-      .uri(URI.create(String.format("http://localhost:%d", this.apiPort)))
-      .GET()
-      .build();
-
-    try {
-      HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
-      return response.statusCode() == 200;
-    } catch (IOException | InterruptedException e) {
-      return false;
-    }
-  }
-
   @Override
   protected String getCurrentVersion() {
     return getVersion(useLatestSauceConnect);

--- a/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectManagerTest.java
+++ b/src/test/java/com/saucelabs/ci/sauceconnect/SauceConnectManagerTest.java
@@ -244,6 +244,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--access-key apiKey");
     String result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -263,6 +264,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--api-key apiKey");
     String result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -282,6 +284,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--auth foo:bar@host:8080");
     String result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -295,6 +298,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "-a foo:bar@host:8080");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -308,6 +312,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "-a foo:bar@host:8080 -a user:pwd@host1:1234 --auth root:pass@host2:9999 --auth uucp:pass@host3:8080");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -327,6 +332,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--proxy user:pwd@host:8080");
     String result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -340,6 +346,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--proxy user@host:8080");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -353,6 +360,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "-x user@host:8080");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -366,6 +374,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apikey",
+            9000,
             "--proxy-sauce user@host:8080");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -385,6 +394,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apiKey",
+            9000,
             "--api-basic-auth user:pwd");
     String result = manager.hideSauceConnectCommandlineSecrets(args);
 
@@ -398,6 +408,7 @@ class SauceConnectManagerTest {
             args,
             "username",
             "apiKey",
+            9000,
             "--api-basic-auth user");
     result = manager.hideSauceConnectCommandlineSecrets(args);
 


### PR DESCRIPTION
## Description
Rely on the apiPort value passed as a method parameter instead of class state.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
